### PR TITLE
add requester to B2B

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Instantiating the class will give you an object with available methods
         - `destinationAccount`: Name used by the business to receive money on the provided destinationChannel. `REQUIRED`
         - `currencyCode`: 3-digit ISO format currency code (e.g `KES`, `USD`, `UGX` etc). `REQUIRED`
         - `amount`: Amount to pay. `REQUIRED`
+        - `requester`: PhoneNumber through which KPLC will send tokens when using B2B to buy electricity tokens.
         - `metadata`: Additional data to associate with the transaction. `REQUIRED`
 
     - **$options:** optional associative array with the following keys:

--- a/src/Payments.php
+++ b/src/Payments.php
@@ -546,6 +546,10 @@ class Payments extends Service
             'metadata' => $metadata
         ];
 
+        if (!empty($parameters['requester'])) {
+            $requestData['requester'] = $parameters['requester'];
+        }
+
         $requestOptions = [
             'json' => $requestData,
         ];


### PR DESCRIPTION
We recently updated the B2B API to enable clients pay for tokens.

The new B2B API has a new field in the request body called requester which allows insertion of a phone number through which KPLC will send tokens.

```
{
  "username": "username",
  "productName": "productname",
  "provider" : "Mpesa",
  "transferType": "BusinessPaybill",
    "currencyCode": "KES",
       "amount": 100,
       "destinationChannel" : "888880", 
       "destinationAccount": "01450717531", 
       "requester":"2547XX...",
      "metadata": {
        "shopId": "1234",
        "itemId": "abcdef"
      }
}
```