### PR TITLE
Update Content.php for Premium Rate Subscriptions

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -1,4 +1,4 @@
-<?php
+			<?php
 
 namespace AfricasTalking\SDK;
 
@@ -17,7 +17,8 @@ class Content extends Service
 		$data = [
 			'username' 	=> $this->username,
 			'to' 		=> implode(",", $options['to']),
-			'message' 	=> $options['message']
+			'message' 	=> $options['message'],
+			'from'  => $options['from']
 		];
 
 		if (array_key_exists('enqueue', $options) && $options['enqueue']) {


### PR DESCRIPTION
Array key from is missing from the variable data on function send. This omission affects premium rate sms when the from key field is supplied during sending of premium messages