### PR TITLE
Move tests to autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
     },
     "autoload": {
         "psr-4": {
-            "AfricasTalking\\SDK\\": "src/",
+            "AfricasTalking\\SDK\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "AfricasTalking\\SDK\\Tests\\": "tests"
         }
     }


### PR DESCRIPTION
Ideally, the sdk end users should not be autoloading `AfricasTalking\SDK\Tests\` namespace